### PR TITLE
Allow for new versions of slumber (version not specified in setup)

### DIFF
--- a/queryset_client/client.py
+++ b/queryset_client/client.py
@@ -734,7 +734,10 @@ class Client(object):
         request_url = self._url_gen(url)
         s = self._main_client._store
         requests = s["session"]
-        serializer = slumber.serialize.Serializer(default_format=s["format"])
+        try:
+            serializer = slumber.serialize.Serializer(default_format=s["format"])
+        except TypeError:
+            serializer = slumber.serialize.Serializer(default=s["format"])
         return serializer.loads(requests.request(method, request_url).content)
 
     def schema(self, model_name=None):


### PR DESCRIPTION
Setup.py does not include a version for slumber, and since 0.3.0 an **init** kwarg has changed name. (Though, confusingly, the CHANGELOG lies about what that change was).
