### PR TITLE
allow for arbitrary fields to be present in response and not the schema ...

### DIFF
--- a/queryset_client/client.py
+++ b/queryset_client/client.py
@@ -539,10 +539,10 @@ def model_gen(**configs):
 
         def _setattrs(self, **kwargs):
             for field in kwargs:
+                self.__setattr__(field, kwargs[field])
                 if not field in self._fields and self._strict_field:
                     raise FieldTypeError("'{0}' is an invalid keyword argument for this function"
                                          .format(field))
-                self.__setattr__(field, kwargs[field])
 
         def __setattr__(self, attr, value):
             self._setfield(attr, value)

--- a/queryset_client/client.py
+++ b/queryset_client/client.py
@@ -539,10 +539,10 @@ def model_gen(**configs):
 
         def _setattrs(self, **kwargs):
             for field in kwargs:
-                self.__setattr__(field, kwargs[field])
-                if not field in self._fields:
+                if not field in self._fields and self._strict_field:
                     raise FieldTypeError("'{0}' is an invalid keyword argument for this function"
                                          .format(field))
+                self.__setattr__(field, kwargs[field])
 
         def __setattr__(self, attr, value):
             self._setfield(attr, value)


### PR DESCRIPTION
...(according to strict_field)

If we expose a custom attribute in the dehydrate method, then this will not be present in the schema (say it is not a field, but is useful). Disabling strict_fields should probably be able to handle this case too, so only complain about fetched attributes that are not in the schema if we are being strict.
