### PR TITLE
JSON serialization and configurable client sessions

### DIFF
--- a/queryset_client/client.py
+++ b/queryset_client/client.py
@@ -743,8 +743,12 @@ class Client(object):
         request_url = self._url_gen(url)
         s = self._main_client._store
         requests = s["session"]
-        serializer = slumber.serialize.Serializer(default_format=s["format"])
-        return serializer.loads(requests.request(method, request_url).content)
+
+        if s["format"] == 'json':
+            return requests.request(method, request_url).json
+        else:
+            serializer = slumber.serialize.Serializer(default_format=s["format"])
+            return serializer.loads(requests.request(method, request_url).content)
 
     def schema(self, model_name=None):
         """ receive schema

--- a/queryset_client/client.py
+++ b/queryset_client/client.py
@@ -721,7 +721,7 @@ class Client(object):
         :param bool strict_field: strict field and convert value in field.
         :param object client:
         """
-        self._main_client = (client or slumber.API)(base_url, auth)
+        self._main_client = client or slumber.API(base_url, auth)
         self._base_url = self._main_client._store["base_url"]
         self._methods_gen(strict_field)
 


### PR DESCRIPTION
This pull request includes two commits.  First, makes the client kwarg to Client() refer to an instance instead of class object.  This allows for the use of a custom requests auth hook:

```
from oauth_hook import OAuthHook
import requests
import slumber
from queryset_client import Client

if __name__ == '__main__':
    oauth_hook = OAuthHook(TOKEN_KEY, TOKEN_SECRET, KEY, SECRET, header_auth=True)

    session = requests.session(hooks={'pre_request': oauth_hook})
    api = slumber.API(
        base_url=ENDPOINT,
        session=session)
    client = Client(ENDPOINT, client=api)
    print list(client.object.objects.all())
```

Secondly, included for your consideration, I encountered issues parsing JSON with the slumber serializer, so the second commit uses the requests library's built in JSON support instead.
